### PR TITLE
Remove unused Git attributes ident

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,7 +1,3 @@
-dnl
-dnl $Id: config.m4,v 1.19 2007/05/16 07:10:38 dickmeiss Exp $
-dnl
-
 PHP_ARG_WITH(yaz,for YAZ support,
 [  --with-yaz[=DIR]        Include YAZ support (ANSI/NISO Z39.50). 
                           DIR is the YAZ bin install directory.])

--- a/config.w32
+++ b/config.w32
@@ -1,4 +1,3 @@
-// $Id: config.w32,v 1.6 2007/06/02 18:52:42 dickmeiss Exp $
 // vim:ft=javascript
 
 ARG_WITH("yaz", "YAZ support (ANSI/NISO Z39.50)", "no");


### PR DESCRIPTION
Hello,

The `$Id$` keywords were used in Subversion where they can be substituted with filename, last revision number change, last changed date, and last user who changed it.

In Git this functionality is different and can be done with Git attribute ident. These need to be defined manually for each file in the `.gitattributes` file and are afterwards replaced with 40-character hexadecimal blob object name which is based only on the particular file contents.

This patch simplifies handling of `$Id$` keywords by removing them since they are not used anymore.

Thanks for considering checking this out or merging it.