### PR TITLE
add arginfo for all functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build-yaz
 build
 configure
 configure.in
+configure.ac
 run-tests.php
 Makefile
 Makefile.global
@@ -16,6 +17,7 @@ aclocal.m4
 install-sh
 libtool
 ltmain.sh
+ltmain.sh.backup
 missing
 mkinstalldirs
 modules

--- a/package.xml
+++ b/package.xml
@@ -51,7 +51,7 @@ Find more information at:
  <dependencies>
   <required>
    <php>
-    <min>4.3</min>
+    <min>5.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>

--- a/php_yaz.c
+++ b/php_yaz.c
@@ -18,6 +18,12 @@
 
 #include "php_yaz.h"
 
+/* for PHP 8+ */
+#ifndef TSRMLS_CC
+#define TSRMLS_CC
+#define TSRMLS_DC
+#endif
+
 #ifndef YAZ_VERSIONL
 #error YAZ version 3.0.2 or later must be used.
 #elif YAZ_VERSIONL < 0x030020
@@ -138,62 +144,165 @@ static int le_link;
 ZEND_GET_MODULE(yaz)
 #endif
 
-#ifdef ZEND_BEGIN_ARG_INFO
-    ZEND_BEGIN_ARG_INFO(first_argument_force_ref, 0)
-        ZEND_ARG_PASS_INFO(1)
-    ZEND_END_ARG_INFO();
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_connect, 0, 0, 1)
+    ZEND_ARG_INFO(0, url)
+    ZEND_ARG_INFO(0, options)
+ZEND_END_ARG_INFO();
 
-    ZEND_BEGIN_ARG_INFO(second_argument_force_ref, 0)
-        ZEND_ARG_PASS_INFO(0)
-        ZEND_ARG_PASS_INFO(1)
-    ZEND_END_ARG_INFO();
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_close, 0, 0, 1)
+    ZEND_ARG_INFO(0, id)
+ZEND_END_ARG_INFO();
 
-    ZEND_BEGIN_ARG_INFO(third_argument_force_ref, 0)
-        ZEND_ARG_PASS_INFO(0)
-        ZEND_ARG_PASS_INFO(0)
-        ZEND_ARG_PASS_INFO(1)
-    ZEND_END_ARG_INFO();
-#else
-static unsigned char first_argument_force_ref[] = {
-        1, BYREF_FORCE };
-static unsigned char second_argument_force_ref[] = {
-        2, BYREF_NONE, BYREF_FORCE };
-static unsigned char third_argument_force_ref[] = {
-        3, BYREF_NONE, BYREF_NONE, BYREF_FORCE };
-#endif
+#define arginfo_yaz_present       arginfo_yaz_close
+
+#define arginfo_yaz_errno         arginfo_yaz_close
+
+#define arginfo_yaz_error         arginfo_yaz_close
+
+#define arginfo_yaz_addinfo       arginfo_yaz_close
+
+#define arginfo_yaz_es_result     arginfo_yaz_close
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_search, 0, 0, 3)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, type)
+    ZEND_ARG_INFO(0, query)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_wait, 0, 0, 0)
+    ZEND_ARG_INFO(1, options)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_hits, 0, 0, 1)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(1, searchresult)
+    ZEND_ARG_INFO(0, query)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_record, 0, 0, 3)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, pos)
+    ZEND_ARG_INFO(0, type)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_syntax, 0, 0, 2)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, syntax)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_element, 0, 0, 2)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, elementsetname)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_schema, 0, 0, 2)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, schema)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_set_option, 0, 0, 2)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, options_or_name)
+    ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_get_option, 0, 0, 2)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, name)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_range, 0, 0, 3)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, start)
+    ZEND_ARG_INFO(0, number)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_sort, 0, 0, 2)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, sortspec)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_itemorder, 0, 0, 2)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, package)
+ZEND_END_ARG_INFO();
+
+#define arginfo_yaz_ccl_conf      arginfo_yaz_itemorder
+
+#define arginfo_yaz_cql_conf      arginfo_yaz_itemorder
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_es, 0, 0, 3)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, type)
+    ZEND_ARG_INFO(0, package)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_scan, 0, 0, 3)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, type)
+    ZEND_ARG_INFO(0, query)
+    ZEND_ARG_INFO(0, flags)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_scan_result, 0, 0, 2)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(1, options)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_ccl_parse, 0, 0, 3)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, query)
+    ZEND_ARG_INFO(1, result)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_yaz_cql_parse, 0, 0, 4)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, cql)
+    ZEND_ARG_INFO(1, result)
+    ZEND_ARG_INFO(0, rev)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_databases, 0, 0, 2)
+    ZEND_ARG_INFO(0, id)
+    ZEND_ARG_INFO(0, package)
+ZEND_END_ARG_INFO();
 
 
 zend_function_entry yaz_functions [] = {
-	PHP_FE(yaz_connect, NULL)
-	PHP_FE(yaz_close, NULL)
-	PHP_FE(yaz_search, NULL)
-	PHP_FE(yaz_wait, first_argument_force_ref)
-	PHP_FE(yaz_errno, NULL)
-	PHP_FE(yaz_error, NULL)
-	PHP_FE(yaz_addinfo, NULL)
-	PHP_FE(yaz_hits, second_argument_force_ref)
-	PHP_FE(yaz_record, NULL)
-	PHP_FE(yaz_syntax, NULL)
-	PHP_FE(yaz_element, NULL)
-	PHP_FE(yaz_range, NULL)
-	PHP_FE(yaz_itemorder, NULL)
-	PHP_FE(yaz_es_result, NULL)
-	PHP_FE(yaz_scan, NULL)
-	PHP_FE(yaz_scan_result, second_argument_force_ref)
-	PHP_FE(yaz_present, NULL)
-	PHP_FE(yaz_ccl_conf, NULL)
-	PHP_FE(yaz_ccl_parse, third_argument_force_ref)
+	PHP_FE(yaz_connect, arginfo_yaz_connect)
+	PHP_FE(yaz_close, arginfo_yaz_close)
+	PHP_FE(yaz_search, arginfo_yaz_search)
+	PHP_FE(yaz_wait, arginfo_yaz_wait)
+	PHP_FE(yaz_errno, arginfo_yaz_errno)
+	PHP_FE(yaz_error, arginfo_yaz_error)
+	PHP_FE(yaz_addinfo, arginfo_yaz_addinfo)
+	PHP_FE(yaz_hits, arginfo_yaz_hits)
+	PHP_FE(yaz_record, arginfo_yaz_record)
+	PHP_FE(yaz_syntax, arginfo_yaz_syntax)
+	PHP_FE(yaz_element, arginfo_yaz_element)
+	PHP_FE(yaz_range, arginfo_yaz_range)
+	PHP_FE(yaz_itemorder, arginfo_yaz_itemorder)
+	PHP_FE(yaz_es_result, arginfo_yaz_es_result)
+	PHP_FE(yaz_scan, arginfo_yaz_scan)
+	PHP_FE(yaz_scan_result, arginfo_yaz_scan_result)
+	PHP_FE(yaz_present, arginfo_yaz_present)
+	PHP_FE(yaz_ccl_conf, arginfo_yaz_ccl_conf)
+	PHP_FE(yaz_ccl_parse, arginfo_yaz_ccl_parse)
 #if YAZ_VERSIONL >= 0x050100
-	PHP_FE(yaz_cql_parse, third_argument_force_ref)
-	PHP_FE(yaz_cql_conf, NULL)
+	PHP_FE(yaz_cql_parse, arginfo_yaz_cql_parse)
+	PHP_FE(yaz_cql_conf, arginfo_yaz_cql_conf)
 #endif
-	PHP_FE(yaz_database, NULL)
-	PHP_FE(yaz_sort, NULL)
-	PHP_FE(yaz_schema, NULL)
-	PHP_FE(yaz_set_option, NULL)
-	PHP_FE(yaz_get_option, NULL)
-	PHP_FE(yaz_es, NULL)
+	PHP_FE(yaz_database, arginfo_databases)
+	PHP_FE(yaz_sort, arginfo_yaz_sort)
+	PHP_FE(yaz_schema, arginfo_yaz_schema)
+	PHP_FE(yaz_set_option, arginfo_yaz_set_option)
+	PHP_FE(yaz_get_option, arginfo_yaz_get_option)
+	PHP_FE(yaz_es, arginfo_yaz_es)
+#ifdef PHP_FE_END
+	PHP_FE_END
+#else
 	{NULL, NULL, NULL}
+#endif
 };
 
 static void get_assoc(INTERNAL_FUNCTION_PARAMETERS, zval *id, Yaz_Association *assocp)


### PR DESCRIPTION
- drop support for PHP 4.x
- add compatibility with PHP 8

**Careful review needed** as this is quite a huge work, and a mistake is quite easy

Using PHP_VERSION : **8.0.0beta4**

```
=====================================================================
PASS yaz_ccl_parse [tests/ccl.phpt] 
PASS yaz_connect [tests/connect.phpt] 
PASS cql [tests/cql.phpt] 
PASS yaz_database [tests/database.phpt] 
PASS yaz_record [tests/record.phpt] 
PASS yaz_connect [tests/scan.phpt] 
=====================================================================

```
